### PR TITLE
fix(issue-4): câmera não inicializa em mini-jogos

### DIFF
--- a/src/game/orchestrator.ts
+++ b/src/game/orchestrator.ts
@@ -41,6 +41,9 @@ export interface AppRefs {
   profileStore: ProfileStore;
   runHistory: RunHistoryStore;
   missions: MissionSystem;
+  /** True quando loadModel + openCamera + start já rodaram (Loading idempotente). */
+  detectorReady: boolean;
+  markDetectorReady: () => void;
 }
 
 export function startApp(): Phaser.Game {
@@ -95,6 +98,8 @@ export function startApp(): Phaser.Game {
     detector, smoother, calibrator, eventDetector, video,
     onSmoothedFrame: (cb) => { smoothedSubs.add(cb); return () => smoothedSubs.delete(cb); },
     profileStore, runHistory, missions,
+    detectorReady: false,
+    markDetectorReady: () => { refs.detectorReady = true; },
   };
 
   const game = new Phaser.Game({

--- a/src/game/scenes/Loading.ts
+++ b/src/game/scenes/Loading.ts
@@ -5,10 +5,17 @@ import { getRefs } from '../orchestrator.ts';
 import type { ErrorKind } from '../../ui/errorScreen.ts';
 import { showError } from '../../ui/errorScreen.ts';
 
+interface LoadingData { next?: string }
+
 export class Loading extends Phaser.Scene {
   private statusText!: Phaser.GameObjects.Text;
+  private nextScene = '';
 
   constructor() { super('Loading'); }
+
+  init(data: LoadingData): void {
+    this.nextScene = data?.next ?? '';
+  }
 
   create(): void {
     const { width, height } = GAME_CONFIG;
@@ -25,11 +32,22 @@ export class Loading extends Phaser.Scene {
   private async bootDetector(): Promise<void> {
     const refs = getRefs(this);
     try {
-      await refs.detector.loadModel((msg) => this.statusText.setText(msg));
-      this.statusText.setText(strings.loading.statusOpeningCamera);
-      await refs.detector.openCamera(refs.video);
-      refs.detector.start(refs.video);
+      // Idempotente: se já carregou modelo + abriu câmera + iniciou, vai direto.
+      if (!refs.detectorReady) {
+        await refs.detector.loadModel((msg) => this.statusText.setText(msg));
+        this.statusText.setText(strings.loading.statusOpeningCamera);
+        await refs.detector.openCamera(refs.video);
+        refs.detector.start(refs.video);
+        refs.markDetectorReady();
+      }
       this.statusText.setText(strings.loading.statusReady);
+      // Destino:
+      // - Se foi passado data.next → vai pra lá
+      // - Senão fluxo original: Tutorial (1ª vez) ou Calibration
+      if (this.nextScene) {
+        this.scene.start(this.nextScene);
+        return;
+      }
       const done = (() => { try { return localStorage.getItem(GAME_CONFIG.storageKeys.tutorialDone) === 'true'; } catch { return false; } })();
       this.scene.start(done ? 'Calibration' : 'Tutorial');
     } catch (err) {

--- a/src/game/scenes/Welcome.ts
+++ b/src/game/scenes/Welcome.ts
@@ -44,7 +44,7 @@ export class Welcome extends Phaser.Scene {
       padding: { x: 20, y: 8 },
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
     minigamesBtn.setName('btn-minigames');
-    minigamesBtn.on('pointerup', () => this.scene.start('MiniGamesHub'));
+    minigamesBtn.on('pointerup', () => this.scene.start('Loading', { next: 'MiniGamesHub' }));
 
     const settingsBtn = this.add.text(width - 24, 24, strings.welcome.settings, {
       fontFamily: 'system-ui', fontSize: '14px', color: '#f5f5f5',


### PR DESCRIPTION
Root cause: botão Mini-jogos pulava Loading.

Fix:
- Welcome → Loading com data { next: 'MiniGamesHub' }
- Loading.init() aceita data.next (skip Tutorial/Calibration default)
- Loading idempotente via refs.detectorReady flag

Refs #4.