### PR TITLE
fix(issue-4): mini-jogos mostram câmera + boneco como fundo

### DIFF
--- a/src/game/scenes/BellRinger.ts
+++ b/src/game/scenes/BellRinger.ts
@@ -5,6 +5,7 @@ import { Bell } from '../entities/Bell.ts';
 import { handAt } from '../../pose/spatialQueries.ts';
 import { getRng } from '../systems/rng.ts';
 import { getRefs } from '../orchestrator.ts';
+import { CameraBackdrop } from '../ui/cameraBackdrop.ts';
 import { Narrator } from '../systems/narrator.ts';
 import { narratorLines } from '../i18n/narratorLines.ts';
 import type { PoseFrame } from '../../pose/types.ts';
@@ -28,6 +29,7 @@ export class BellRinger extends Phaser.Scene {
   private narrator!: Narrator;
   private session: string[] = [];
   private rng: () => number = Math.random;
+  private backdrop: CameraBackdrop | null = null;
 
   constructor() { super('BellRinger'); }
 
@@ -55,6 +57,7 @@ export class BellRinger extends Phaser.Scene {
     }).setOrigin(1, 0);
 
     const refs = getRefs(this);
+    this.backdrop = new CameraBackdrop(this, refs.video, refs.onSmoothedFrame);
     this.narrator = new Narrator(null, true);
     this.unsubFrame = refs.onSmoothedFrame((frame: PoseFrame) => this.handleFrame(frame));
   }
@@ -118,6 +121,7 @@ export class BellRinger extends Phaser.Scene {
 
   shutdown(): void {
     if (this.unsubFrame) { this.unsubFrame(); this.unsubFrame = null; }
+    if (this.backdrop) { this.backdrop.destroy(); this.backdrop = null; }
     for (const b of this.bells) b.destroy();
     this.bells = [];
   }

--- a/src/game/scenes/CatchBicho.ts
+++ b/src/game/scenes/CatchBicho.ts
@@ -5,6 +5,7 @@ import { Bicho, type BichoColor } from '../entities/Bicho.ts';
 import { handAt } from '../../pose/spatialQueries.ts';
 import { getRng } from '../systems/rng.ts';
 import { getRefs } from '../orchestrator.ts';
+import { CameraBackdrop } from '../ui/cameraBackdrop.ts';
 import { Narrator } from '../systems/narrator.ts';
 import { narratorLines } from '../i18n/narratorLines.ts';
 import type { PoseFrame } from '../../pose/types.ts';
@@ -30,6 +31,7 @@ export class CatchBicho extends Phaser.Scene {
   private narrator!: Narrator;
   private session: string[] = [];
   private rng: () => number = Math.random;
+  private backdrop: CameraBackdrop | null = null;
 
   constructor() { super('CatchBicho'); }
 
@@ -55,6 +57,7 @@ export class CatchBicho extends Phaser.Scene {
     }).setOrigin(1, 0);
 
     const refs = getRefs(this);
+    this.backdrop = new CameraBackdrop(this, refs.video, refs.onSmoothedFrame);
     this.narrator = new Narrator(null, true);
     this.unsubFrame = refs.onSmoothedFrame((frame: PoseFrame) => this.handleFrame(frame));
   }
@@ -110,6 +113,7 @@ export class CatchBicho extends Phaser.Scene {
 
   shutdown(): void {
     if (this.unsubFrame) { this.unsubFrame(); this.unsubFrame = null; }
+    if (this.backdrop) { this.backdrop.destroy(); this.backdrop = null; }
     for (const b of this.bichos) b.destroy();
     this.bichos = [];
   }

--- a/src/game/scenes/TrunkTwist.ts
+++ b/src/game/scenes/TrunkTwist.ts
@@ -4,6 +4,7 @@ import { strings } from '../../i18n/strings.ts';
 import { TrunkTarget } from '../entities/TrunkTarget.ts';
 import { trunkRotationAngle } from '../../pose/spatialQueries.ts';
 import { getRefs } from '../orchestrator.ts';
+import { CameraBackdrop } from '../ui/cameraBackdrop.ts';
 import { Narrator } from '../systems/narrator.ts';
 import { narratorLines } from '../i18n/narratorLines.ts';
 import type { PoseFrame } from '../../pose/types.ts';
@@ -23,6 +24,7 @@ export class TrunkTwist extends Phaser.Scene {
   private unsubFrame: (() => void) | null = null;
   private narrator!: Narrator;
   private session: string[] = [];
+  private backdrop: CameraBackdrop | null = null;
 
   constructor() { super('TrunkTwist'); }
 
@@ -45,6 +47,7 @@ export class TrunkTwist extends Phaser.Scene {
     this.spawnNext();
 
     const refs = getRefs(this);
+    this.backdrop = new CameraBackdrop(this, refs.video, refs.onSmoothedFrame);
     this.narrator = new Narrator(null, true);
     this.unsubFrame = refs.onSmoothedFrame((frame: PoseFrame) => this.handleFrame(frame));
   }
@@ -98,6 +101,7 @@ export class TrunkTwist extends Phaser.Scene {
 
   shutdown(): void {
     if (this.unsubFrame) { this.unsubFrame(); this.unsubFrame = null; }
+    if (this.backdrop) { this.backdrop.destroy(); this.backdrop = null; }
     if (this.current) { this.current.destroy(); this.current = null; }
   }
 }

--- a/src/game/ui/cameraBackdrop.ts
+++ b/src/game/ui/cameraBackdrop.ts
@@ -1,0 +1,69 @@
+import * as Phaser from 'phaser';
+import { KeypointOverlay } from '../../ui/keypointOverlay.ts';
+import type { PoseFrame } from '../../pose/types.ts';
+import { GAME_CONFIG } from '../config.ts';
+
+/**
+ * Renderiza vídeo da câmera (espelhado) + boneco de palito de keypoints como
+ * fundo da cena Phaser. Usado nas cenas de mini-jogo pra orientar o jogador.
+ *
+ * Implementação: bake do video + overlay num canvas offscreen → expõe como
+ * texture Phaser via `textures.addCanvas` → `refresh()` por frame.
+ */
+export class CameraBackdrop {
+  private canvas: HTMLCanvasElement;
+  private overlay: KeypointOverlay;
+  private image: Phaser.GameObjects.Image;
+  private rafId: number | null = null;
+  private unsub: (() => void) | null = null;
+  private lastFrame: PoseFrame | null = null;
+  private video: HTMLVideoElement;
+  private scene: Phaser.Scene;
+  private textureKey: string;
+
+  constructor(
+    scene: Phaser.Scene,
+    video: HTMLVideoElement,
+    onSmoothedFrame: (cb: (f: PoseFrame) => void) => () => void,
+    opacity = 0.55,
+  ) {
+    this.scene = scene;
+    this.video = video;
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = GAME_CONFIG.width;
+    this.canvas.height = GAME_CONFIG.height;
+    this.overlay = new KeypointOverlay(this.canvas);
+    this.textureKey = `camera_bg_${scene.scene.key}_${Date.now()}`;
+    scene.textures.addCanvas(this.textureKey, this.canvas);
+    this.image = scene.add.image(0, 0, this.textureKey)
+      .setOrigin(0, 0)
+      .setDepth(-100)
+      .setAlpha(opacity);
+
+    this.unsub = onSmoothedFrame((f) => { this.lastFrame = f; });
+    this.tick();
+  }
+
+  private tick = (): void => {
+    const ctx = this.canvas.getContext('2d');
+    if (ctx && this.video.videoWidth > 0) {
+      ctx.save();
+      ctx.translate(this.canvas.width, 0);
+      ctx.scale(-1, 1);
+      ctx.drawImage(this.video, 0, 0, this.canvas.width, this.canvas.height);
+      ctx.restore();
+      if (this.lastFrame) this.overlay.draw(this.lastFrame.keypoints, this.lastFrame.confidence);
+      const tex = this.scene.textures.get(this.textureKey) as Phaser.Textures.CanvasTexture;
+      tex.refresh();
+    }
+    this.rafId = requestAnimationFrame(this.tick);
+  };
+
+  destroy(): void {
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+    if (this.unsub) { this.unsub(); this.unsub = null; }
+    this.image.destroy();
+    if (this.scene.textures.exists(this.textureKey)) this.scene.textures.remove(this.textureKey);
+  }
+}


### PR DESCRIPTION
User feedback: sem ver o próprio corpo é cego. Adiciona CameraBackdrop helper que renderiza video espelhado + keypoints como fundo (depth -100, alpha 0.55) nos 3 mini-jogos. Refs #4.